### PR TITLE
Fix "RuntimeError: The size of tensor a (3) must match the size of tensor b (4) at non-singleton dimension 1"

### DIFF
--- a/app.py
+++ b/app.py
@@ -297,6 +297,9 @@ class StableVideo:
             f_atlas_origin = transforms.ToTensor()(self.f_atlas_origin).unsqueeze(0).cuda()
             f_atlas = transforms.ToTensor()(f_atlas).unsqueeze(0).cuda()
             mask = transforms.ToTensor()(mask).unsqueeze(0).cuda()
+            if f_atlas.shape != mask.shape:
+                print("Warning: truncating mask to atlas shape {}".format(f_atlas.shape))
+                mask = mask[:f_atlas.shape[0], :f_atlas.shape[1], :f_atlas.shape[2], :f_atlas.shape[3]]
             f_atlas = f_atlas * (1 - mask) + f_atlas_origin * mask
         
         f_atlas = torch.nn.functional.pad(


### PR DESCRIPTION
Steps to Reproduce (on Ubuntu 22.04, PyTorch 2.0.1, CUDA 12.0)

1. Follow README to download dependencies, controlNet, and sample videos

2. Run app.py

3. Using default settings (car video) click Load Video, then Foreground, then Background

4. Click Render

Expected:
    Video will render

Actual:
    Gradio UI crashes with the following error:
```
Global seed set to 1768998891
Data shape for DDIM sampling is (1, 4, 64, 104), eta 0.0
Running DDIM Sampling with 20 timesteps
DDIM Sampler: 100%|███████████████████████████████████████████████████████| 20/20 [00:06<00:00,  3.08it/s]
Traceback (most recent call last):
  File "venv/lib/python3.10/site-packages/gradio/routes.py", line 422, in run_predict
    output = await app.get_blocks().process_api(
  File "venv/lib/python3.10/site-packages/gradio/blocks.py", line 1323, in process_api
    result = await self.call_function(
  File "venv/lib/python3.10/site-packages/gradio/blocks.py", line 1051, in call_function
    prediction = await anyio.to_thread.run_sync(
  File "venv/lib/python3.10/site-packages/anyio/to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "StableVideo/app.py", line 300, in render
    f_atlas = f_atlas * (1 - mask) + f_atlas_origin * mask
RuntimeError: The size of tensor a (3) must match the size of tensor b (4) at non-singleton dimension 1
```


